### PR TITLE
Add blink.js to existing page

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -4,7 +4,7 @@
 
   // Comms stuff
 
-  var ws = location.href.replace("http", "ws");
+  var ws = "ws://127.0.0.1:"+port;
   if (!/\/\d+$/.test(ws)) {
     ws += '/' + id;
   }

--- a/src/AtomShell/main.js
+++ b/src/AtomShell/main.js
@@ -78,6 +78,12 @@ function createWindow(opts) {
   return win.id;
 }
 
+function addblink(opts) {
+  var win = windows[opts.id];
+  win.webContents.executeJavaScript(`var id = ${opts.id}, port = ${opts.port}`);
+  win.webContents.executeJavaScript(`${opts.script}`);
+}
+
 function evalwith(obj, code) {
   return (function() {
     return eval(code);

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -3,7 +3,7 @@ import Blink: js, jsstring, id
 import Base: position, size, close
 
 export Window, flashframe, shell, progress, title,
-  centre, floating, loadurl, opentools, closetools, tools,
+  centre, floating, addblink, loadurl, opentools, closetools, tools,
   loadhtml, loadfile, css, front
 
 type Window
@@ -92,6 +92,12 @@ floating(win::Window, flag) =
 
 floating(win::Window) =
   @dot win isAlwaysOnTop()
+
+function addblink(win::Window)
+  script = open(readall,Pkg.dir("Blink","res","blink.js"))
+  opts = @d(:id=>win.id,:port=>Blink.port,:script=>script)
+  @js_ shell(win) addblink($opts)
+end
 
 loadurl(win::Window, url) =
   @dot win loadURL($url)

--- a/src/content/main.html
+++ b/src/content/main.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script>var id = {{id}}</script>
+    <script>var id = {{id}}, port = {{port}}</script>
     <script src="blink.js"></script>
     <link rel="stylesheet" href="reset.css">
     <link rel="stylesheet" href="blink.css">

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -13,14 +13,14 @@ const resroute =
 
 const maintp = Mustache.template_from_file(joinpath(dirname(@__FILE__), "main.html"))
 
-app(f) = req -> render(maintp, d("id"=>Page(f).id))
+app(f) = req -> render(maintp, d("id"=>Page(f).id,"port"=>Blink.port))
 
 function page_handler(req)
   id = try parse(req[:params][:id]) catch e @goto fail end
   haskey(pool, id) || @goto fail
   active(pool[id].value) && @goto fail
 
-  return render(maintp, d("id"=>id))
+  return render(maintp, d("id"=>id,"port"=>Blink.port))
 
   @label fail
   return d(:body => "Not found",


### PR DESCRIPTION
``` julia
julia> using Blink
julia> w = Window()
julia> loadurl(w,"http://www.julialang.org")
julia> Blink.addblink(w)
julia> loadjs!(w,"https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.js")
julia> @js w d3.select(".title").text("Blink Rocks!")
```

This PR adds blink.js to an existing webpage so you can interact with it from Julia. The script above will load the Julia web page, add blink.js to the page, use blink.js to load d3.js and use d3.js to replace the Julia logo with "Blink Rocks!". It currently only works for "http" and _not_ for "https".

To get this to work, I had to assume the WebSocket server is running on local host (which I think is safe?) and added a new JS variable "port" in addition to the current "id" to blink.js.

I'm still learning Blink.jl (and Julia and JavaScript for that matter), so suggestions are most welcome :)
