### PR TITLE
Prevent possible port collision

### DIFF
--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -63,7 +63,7 @@ function electron()
   return path
 end
 
-ports() = shuffle(MersenneTwister(rand(UInt)), Vector(2_000:10_1000))[1:2]
+ports() = shuffle(MersenneTwister(rand(UInt)), Vector(2_000:10_000))[1:2]
 
 function try_connect(args...; interval = 0.01, attempts = 300)
   for i = 1:attempts

--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -63,7 +63,7 @@ function electron()
   return path
 end
 
-port() = rand(2_000:10_000)
+ports() = rand(2_000:10_000, 2)
 
 function try_connect(args...; interval = 0.01, attempts = 300)
   for i = 1:attempts
@@ -78,7 +78,7 @@ end
 
 function init(; debug = false)
   electron() # Check path exists
-  p, dp = port(), port()
+  p, dp = ports()
   debug && inspector(dp)
   dbg = debug ? "--debug=$dp" : []
   proc = (debug ? run_rdr : run)(`$(electron()) $dbg $mainjs port $p`; wait=false)

--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -1,4 +1,4 @@
-using Lazy, JSON, MacroTools
+using Lazy, JSON, MacroTools, Random
 
 hascommand(c) =
   try read(`which $c`, String); true catch e false end
@@ -63,7 +63,7 @@ function electron()
   return path
 end
 
-ports() = rand(2_000:10_000, 2)
+ports() = shuffle(MersenneTwister(rand(UInt)), Vector(2_000:10_1000))[1:2]
 
 function try_connect(args...; interval = 0.01, attempts = 300)
   for i = 1:attempts


### PR DESCRIPTION
While it's a small chance, calling `port()` twice for the debug and non-debug ports may lead to an unlucky draw with both ports come up the same value. By changing the `rand` call to select 2 items from the valid port range instead of calling `rand` twice, we can avoid this possibility entirely. Similarly, I've changed `port` to `ports` to reflect that it returns an array.