### PR TITLE
Do not force white background

### DIFF
--- a/res/blink.css
+++ b/res/blink.css
@@ -1,5 +1,3 @@
-body { background: white; }
-
 .vcentre { display:table; position:absolute; width:100%; height:100%; }
 .vcentre > :first-child { display: table-cell; vertical-align: middle; }
 .hcentre { margin-left: auto; margin-right: auto; }


### PR DESCRIPTION
The default background is white anyway. Forcing a white background messes up with Interact styling. Trying to have a dark style fails as inside the body the css set by Blink prevails (I don't understand the rules of css well enough to know why), see for example [this issue](https://github.com/JuliaGizmos/Interact.jl/issues/331#issue-478597259).