### PR TITLE
Fix travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Blink.jl
-[![Build Status](https://travis-ci.org/JuliaGizmos/Blink.jl.svg?branch=master)](https://travis-ci.org/JunoLab/Blink.jl)
+[![Build Status](https://travis-ci.org/JuliaGizmos/Blink.jl.svg?branch=master)](https://travis-ci.org/JuliaGizmos/Blink.jl)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGizmos.github.io/Blink.jl/stable)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaGizmos.github.io/Blink.jl/latest)
 


### PR DESCRIPTION
It would also be good to trigger the CI to build the docs for `stable`