### PR TITLE
Fixed new location of 7z.exe in Julia 1.3.0

### DIFF
--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -65,6 +65,10 @@ function install()
            juliaversions = VersionNumber.([replace(f, "Julia-" => "") for f in juliafolders])
            i = findlast(isequal(maximum(juliaversions)), juliaversions)
            zipper = joinpath(ENV["LOCALAPPDATA"], juliafolders[i], "bin", "7z.exe")
+           if !isfile(zipper)
+            # we are probably in >= Julia 1.3.0, where 7z.exe is located in /libexec
+            zipper = joinpath(ENV["LOCALAPPDATA"], juliafolders[i], "libexec", "7z.exe")
+           end
            isfile(zipper) || error("could not find $zipper. Try also installing a binary version of Julia.")
         end
         cmd = Cmd([zipper, "x", file, "-oatom"])

--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -48,7 +48,11 @@ function install()
        arch = Int == Int64 ? "x64" : "ia32"
        file = "electron-v$version-win32-$arch.zip"
        download("https://github.com/electron/electron/releases/download/v$version/$file")
-       zipper = joinpath(Base.Sys.BINDIR, "7z.exe")
+       if VERSION >= v"1.3.0"
+           zipper = joinpath(Base.Sys.BINDIR, "..", "libexec", "7z.exe")
+       else
+           zipper = joinpath(Base.Sys.BINDIR, "7z.exe")
+       end
        if !isfile(zipper)
            #=
            This is likely built with cygwin, which includes its own version of 7z.
@@ -59,6 +63,7 @@ function install()
            Julia, so instead we look in the default Julia binary location and
            pick the latest version.
            =#
+           
            juliafolders = filter(readdir(ENV["LOCALAPPDATA"])) do f
                                      startswith(f, "Julia-")
               end
@@ -66,8 +71,8 @@ function install()
            i = findlast(isequal(maximum(juliaversions)), juliaversions)
            zipper = joinpath(ENV["LOCALAPPDATA"], juliafolders[i], "bin", "7z.exe")
            if !isfile(zipper)
-            # we are probably in >= Julia 1.3.0, where 7z.exe is located in /libexec
-            zipper = joinpath(ENV["LOCALAPPDATA"], juliafolders[i], "libexec", "7z.exe")
+               # we are probably in >= Julia 1.3.0, where 7z.exe is located in /libexec
+               zipper = joinpath(ENV["LOCALAPPDATA"], juliafolders[i], "libexec", "7z.exe")
            end
            isfile(zipper) || error("could not find $zipper. Try also installing a binary version of Julia.")
         end


### PR DESCRIPTION
In Julia 1.3.0 7z.exe is moved into the /libexec folder. This fixes [this issue](https://github.com/JuliaGizmos/Blink.jl/issues/224) I described. 

It is not necessarily a neat solution, especially since the error message is quite verbose (someone building on <1.3.0 will get the error that `libexec/7z.exe` does not exist, but he has to put `7z.exe` in the `bin` folder).

Slight side note, but is there a reason why we cannot use the `joinpath(Sys.BINDIR, "..", "libexec", "7z.exe")` instead of manually looking for folders called `Julia-*` in the `ENV["LOCALAPPDATA"]` folder?  Now there is no support for custom installation locations etc.