### PR TITLE
Add !-postfix to modifying methods, prefer to extends Base methods.

### DIFF
--- a/test/AtomShell/window.jl
+++ b/test/AtomShell/window.jl
@@ -6,10 +6,10 @@ using Test
 # unknown reasons.
 w = Window(Blink.@d(:show => false, :width=>150, :height=>100), async=false);
 @testset "size Tests" begin
-    @test size(w) == [150,100]
+    @test size(w) == (150, 100)
 
-    size(w, 200,200)
-    @test size(w) == [200,200]
+    size(w, 200, 200)
+    @test size(w) == (200, 200)
 end
 
 # @testset "async" begin


### PR DESCRIPTION
This should™ be fully backwards compatible.

I didn't want to add deprecation messages because that would just be cluttering.

Closes #161.