### PR TITLE
Require BinDeps v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
 julia = "1"
-BinDeps = "0.8, 1.0"
+BinDeps = "1.0"
 JSExpr = "0.5"
 JSON = "0.21"
 Lazy = "0.13, 0.14"


### PR DESCRIPTION
Fixes #247 (kinda).

BinDeps 1.0 works on Julia 1.0+, so it should be okay to drop support for 0.8.