### PR TITLE
Don't check the Window, check the Page

### DIFF
--- a/src/AtomShell/webio.jl
+++ b/src/AtomShell/webio.jl
@@ -29,4 +29,4 @@ function Sockets.send(comm::WebIOBlinkComm, data)
     msg(comm.window, Dict(:type=>"webio", :data=>data))
 end
 
-Base.isopen(comm::WebIOBlinkComm) = active(comm.window)
+Base.isopen(comm::WebIOBlinkComm) = active(comm.window.content)


### PR DESCRIPTION
Fixes https://github.com/JuliaGizmos/WebIO.jl/issues/357 and https://github.com/JuliaGizmos/Interact.jl/issues/344

I don't know why exactly, I'd like to know though if anyone knows the difference between `active(comm.window)`  and  `active(comm.window.content)`? Is there a possibility of deadlock or some other funny business if `active(comm.window)` is called from two different tasks/threads?

Nonetheless I think we should probably just merge this since:

a) this PR just restores the code from before the WebIO integration was moved here (and was probably just [accidentally](https://github.com/JuliaGizmos/Interact.jl/issues/344#issuecomment-612944016) changed then)
b) WebIO, and thus PlotlyJS, Interact, etc. are somewhat broken in Blink without this for more complex UIs (see linked issues)

(fyi @travigd)
