### PR TITLE
Updates macros to Julia 1.6 macro scoping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       julia: 1.0
       env: TESTCMD="xvfb-run julia"
     - os: linux
-      julia: 1.3
+      julia: 1
       env: TESTCMD="xvfb-run julia"
     - os: linux
       julia: nightly
@@ -18,14 +18,14 @@ matrix:
       julia: 1.0
       env: TESTCMD="julia"
     - os: osx
-      julia: 1.3
+      julia: 1
       env: TESTCMD="julia"
     - os: osx
       julia: nightly
       env: TESTCMD="julia"
 
     - stage: "Documentation"
-      julia: 1.3
+      julia: 1
       os: linux
       script:
         - julia --project=docs/ --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); Pkg.instantiate()'

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
-julia = "1"
 BinDeps = "0.8, 1.0"
 JSExpr = "0.5"
 JSON = "0.21, 1.0"
@@ -31,6 +30,7 @@ Mux = "0.7"
 Reexport = "0.2"
 WebIO = "=0.8.0, =0.8.1, =0.8.2, =0.8.3, =0.8.4, =0.8.5, 0.8.7"
 WebSockets = "1.5"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -98,11 +98,11 @@ dot(w::Window, code; callback = true) =
 dot_(args...) = dot(args..., callback = false)
 
 macro dot(win, code)
-  :(dot($(esc(win)), $(Expr(:quote, Expr(:., :this, QuoteNode(code))))))
+  :(dot($(esc(win)), $(esc(Expr(:quote, Expr(:., :this, QuoteNode(code)))))))
 end
 
 macro dot_(win, code)
-  :(dot_($(esc(win)), $(Expr(:quote, Expr(:., :this, QuoteNode(code))))))
+  :(dot_($(esc(win)), $(esc(Expr(:quote, Expr(:., :this, QuoteNode(code)))))))
 end
 
 # Base.* methods

--- a/src/rpc/rpc.jl
+++ b/src/rpc/rpc.jl
@@ -79,7 +79,7 @@ julia> @js_ win for i in 1:x console.log(i) end
 ```
 """
 macro js(o, ex)
-    :(js($(esc(o)), $(Expr(:quote, ex))))
+    :(js($(esc(o)), $(esc(Expr(:quote, ex)))))
 end
 
 """
@@ -102,5 +102,5 @@ julia> @js_ win for i in 1:x console.log(i) end
 ```
 """
 macro js_(o, ex)
-    :(js($(esc(o)), $(Expr(:quote, ex)), callback=false))
+    :(js($(esc(o)), $(esc(Expr(:quote, ex))), callback=false))
 end


### PR DESCRIPTION
This should make tests pass on 1.6.

Enable testing on latest release