### PR TITLE
remove dependency on WebSockets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blink"
 uuid = "ad839575-38b3-5650-b840-f874b8c74a25"
 authors = []
-version = "0.12.5"
+version = "0.12.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Mux = "a975b10e-0019-58db-a62f-e48ff68538c9"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
-WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [compat]
 BinDeps = "0.8, 1.0"
@@ -26,11 +26,11 @@ JSON = "0.21, 1.0"
 Lazy = "0.13, 0.14, 0.15"
 MacroTools = "0.4, 0.5"
 Mustache = "0.5, 1.0"
-Mux = "0.7"
+Mux = "1.0"
 Reexport = "0.2, 1"
 WebIO = "=0.8.0, =0.8.1, =0.8.2, =0.8.3, =0.8.4, =0.8.5, 0.8.7"
-WebSockets = "1.5"
-julia = "1"
+HTTP = "1.5.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/content/content.jl
+++ b/src/content/content.jl
@@ -1,4 +1,6 @@
-using Mux, WebSockets, JSON, Lazy, Mustache
+using Mux, JSON, Lazy, Mustache
+import HTTP: WebSocket
+import HTTP.WebSockets: isclosed
 
 export Page, id, active
 
@@ -30,7 +32,7 @@ end
 include("config.jl")
 
 id(p::Page) = p.id
-active(p::Page) = isdefined(p, :sock) && isopen(p.sock) && isopen(p.sock.socket)
+active(p::Page) = isdefined(p, :sock) && !isclosed(p.sock)
 handlers(p::Page) = p.handlers
 
 function Base.wait(p::Page)
@@ -40,7 +42,7 @@ end
 
 function msg(p::Page, m)
   active(p) || wait(p)
-  write(p.sock, json(m))
+  send(p.sock, json(m))
 end
 
 const pool = Dict{Int, WeakRef}()


### PR DESCRIPTION
As HTTP package has support for web sockets now and the actual package WebSockets is having hard time to keep up with HTTP updates, why not simplify dependency  chain