### PR TITLE
Bugfixes and API changes for updated Electron

### DIFF
--- a/src/AtomShell/preload.js
+++ b/src/AtomShell/preload.js
@@ -1,0 +1,22 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+/* This will execute require on the scripts given as arguments and ignore other args because the regex turns them empty (false)  */
+process.argv.map(str => str.replace(/((?:^--blink-preloadjs=)|(?:^.*$))/, '')).filter(Boolean).forEach(function (filepath) {
+    try {
+        require(filepath);
+    } catch (err) {
+        console.log(err);
+    }
+});
+
+const dialogHandlers = {
+    showOpenDialog: (opts, cb) => ipcRenderer.invoke("dialog:openFile", opts).then(res => cb(res.filePaths)),
+    showSaveDialog: (opts, cb) => ipcRenderer.invoke("dialog:saveFile", opts).then(res => cb(res.filePath)),
+};
+
+/* If a user disables contextIsolation we'll need to handle that. */
+if (process.contextIsolated) {
+    contextBridge.exposeInMainWorld('dialog', dialogHandlers);
+} else {
+    window.dialog = dialogHandlers;
+}


### PR DESCRIPTION
The API for performing dialog operations has changed significantly since the last version of Electron used in the package. Specifically, this PR makes the necessary backend changes to remedy issues with the dialog widgets seen with the updated Electron from Blink >=v0.12.6. This PR may require additional thought about an update to `Project.toml` to ensure that the mutual dependencies on the patches will be satisfied by users of both packages.

This patch provides the following improvements:
1) A more robust override mechanism for `BrowserWindow` defaults.
2) Compatibility with or without `contextIsolation` for asynchronous dialog operations.
3) A user friendly mechanism for adding renderer preload scripts to extend the namespace of isolated windows.
4) Miscellaneous bugfixes: Julia icon path, keys in `window_defaults` dictionary, syntax update for invoking debugger.


| Blink.jl                       | InteractBase.jl      | Status                   |
|--------------------------------|----------------------|--------------------------|
| Blink v0.12.5 (Electron 4.04)  | InteractBase v0.10.5 | Working                  |
| Blink v0.12.5 (Electron 4.04)  | InteractBase v0.10.9 | Broken (theme undefined) |
| Blink v0.12.5 (Electron 4.04)  | [InteractBase #177](https://github.com/piever/InteractBase.jl/pull/177)    | Working                  |
| Blink v0.12.5 (Electron 4.04)  | [InteractBase #178](https://github.com/piever/InteractBase.jl/pull/178)    | Broken (no dialog)  |

| Blink.jl                       | InteractBase.jl      | Status                   |
|--------------------------------|----------------------|--------------------------|
| Blink v0.12.6 (Electron 19.09) | InteractBase v0.10.9 | Broken (theme undefined) |
| Blink v0.12.7 (Electron 19.09) | InteractBase v0.10.9 | Broken (theme undefined) |
| Blink v0.12.7 (Electron 19.09) | [InteractBase #177](https://github.com/piever/InteractBase.jl/pull/177)    | Broken (no dialog)       |
| [Blink #309](https://github.com/JuliaGizmos/Blink.jl/pull/309) (Electron 19.09)    | [InteractBase #177](https://github.com/piever/InteractBase.jl/pull/177)    | Broken (no dialog)       |
| [Blink #309](https://github.com/JuliaGizmos/Blink.jl/pull/309) (Electron 19.09)    | [InteractBase #178](https://github.com/piever/InteractBase.jl/pull/178)    | Working                  |