### PR TITLE
Delay execution of blink.js while document loads

### DIFF
--- a/src/content/main.html
+++ b/src/content/main.html
@@ -3,7 +3,7 @@
   <head>
     <script>var id = {{id}}</script>
     <script>{{optional_create_window_callback}}</script>
-    <script src="blink.js"></script>
+    <script src="blink.js" defer></script>
     <script src="webio.bundle.js"></script>
     <link rel="stylesheet" href="reset.css">
     <link rel="stylesheet" href="blink.css">


### PR DESCRIPTION
After the first window, I found that the callback for window creation was being executed quickly enough that the `initwebio!(w)` method is triggered before the page has fully loaded (and hence before `webio` exists). Adding the [`defer` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer) to the `blink.js` script ensures it won't be executed until after the browser has had a chance to load in the `webio.bundled.js` package.

Fixes [Blink.jl#300](https://github.com/JuliaGizmos/Blink.jl/issues/300), [WebIO.jl#505](https://github.com/JuliaGizmos/WebIO.jl/issues/505), and [PlotlyJS.jl#460](https://github.com/JuliaPlots/PlotlyJS.jl/issues/460).