### PR TITLE
add option to close server and end electron process

### DIFF
--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -105,7 +105,7 @@ handlers(shell::Electron) = shell.handlers
 function initcbs(shell)
   enable_callbacks!(shell)
   @async begin
-    while active(shell)
+    while active(shell) && !eof(shell.sock)  # check for eof to prevent errors during shutdown
       @errs handle_message(shell, JSON.parse(shell.sock))
     end
   end

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -1,5 +1,5 @@
 using ..Blink
-import Blink: js, id
+import Blink: js, id, stopserve
 import JSExpr: JSString, jsstring
 import Base: position, size, close
 
@@ -254,8 +254,14 @@ tools(win::Window) =
 front(win::Window) =
   @dot win showInactive()
 
-close(win::Window) =
+function close(win::Window; quit=false)
   @dot win close()
+  if quit
+    close(win.shell)
+    stopserve()
+  end
+
+end
 
 # Window content APIs
 

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -62,11 +62,16 @@ http_default =
       Mux.notfound())
 
 const serving = Ref(false)
+const server = Ref{Mux.HTTP.Servers.Server}()
 
 function serve()
   serving[] && return
   serving[] = true
-  @async begin
-    Mux.serve(Mux.App(http_default), Mux.App(ws_handler), ip"127.0.0.1", port[])
-  end
+  server[] = Mux.serve(Mux.App(http_default), Mux.App(ws_handler), ip"127.0.0.1", port[])
+end
+
+function stopserve()
+  serving[] || return
+  serving[] = false
+  close(server[])
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGizmos/Blink.jl/issues/317.

Added a new keyword argument to the `close(win)` function. Now, `close(win, quit=true)` shuts down the Mux/HTTP server and also closes the shell socket connection, allowing the electron process to shut down cleanly.

