### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blink"
 uuid = "ad839575-38b3-5650-b840-f874b8c74a25"
 authors = []
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
To release @alexriss's fixup in #318 that stops precomilation from hanging in 1.10

cc @pfitzseb who merged that PR.