### PR TITLE
Loading blink.js on loadURL

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -5,6 +5,12 @@
   // Comms stuff
 
   var ws = location.href.replace("http", "ws");
+
+  // use specified url if it exists (supplied by createWindow opts)
+  if (document.ws) {
+    ws = document.ws;
+  }
+
   if (!/\/\d+$/.test(ws)) {
     ws += '/' + id;
   }

--- a/src/AtomShell/main.js
+++ b/src/AtomShell/main.js
@@ -77,11 +77,40 @@ app.on("ready", function() {
 // Window creation
 var windows = {};
 
-function createWindow(opts) {
+function createWindow(opts, comUrl) {
   var win = new BrowserWindow(opts);
   windows[win.id] = win;
   if (opts.url) {
     win.loadURL(opts.url);
+
+    windows[win.id].comUrl = comUrl;
+
+    // load blink.js and webio.bundle.js
+    win.webContents.on('did-finish-load', function() {
+      win.webContents.executeJavaScript(`
+        // is blink.js already loaded?
+        if (typeof Blink != 'object') {
+          var comUrl = '${comUrl ? comUrl : windows[win.id].comUrl}';
+          var port = comUrl.split(":").pop().split("/")[0];
+          var id = comUrl.split("/").pop()[0];
+          var urlParams = new URLSearchParams(comUrl);
+          var callback_id = urlParams.get('callback');
+
+          document.ws = comUrl.replace("http", "ws");
+
+          var script = document.createElement('script');
+          script.defer = true;
+          script.type = 'text/javascript';
+          script.src = 'http://localhost:' + port + '/blink.js';
+          document.head.appendChild(script);
+
+          var script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.src =  'http://localhost:' + port + '/webio.bundle.js';
+          document.head.appendChild(script);
+        }
+      `);
+    });
   }
   win.setMenu(null);
 

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -42,7 +42,10 @@ function ws_handler(ws)
   p.sock = ws
   @async @errs get(handlers(p), "init", identity)(p)
   try
-    put!(p.cb, true)
+    # set only on first websocket connection initialization
+    if !isready(p.cb)
+      put!(p.cb, true)
+    end
   catch e
     @warn e
   end

--- a/test/content/api.jl
+++ b/test/content/api.jl
@@ -19,6 +19,17 @@ w = Window(Blink.Dict(:show => false), async=false);
     @test (@js w document.getElementById("b").innerHTML) == "bye"
 end
 
+temp_dir = tempdir()
+temp_html = joinpath(temp_dir, "temp.html")
+write(temp_html, """<html><head><title>Test</title></head><body><div id="a">Test</div></body></html>""")
+w_url = Window(Blink.Dict(:url => "file://" * temp_html, :show => false), async=false);
+@testset "blink.js is included in document when using loadurl" begin
+    sleep(1) # wait for page to load
+
+    @test (@js w_url document.getElementById("a").innerHTML) == "Test"
+    @test (@js w_url [].filter.call(document.scripts, function (script) return script.src.includes("blink.js") end).length) == 1
+end
+
 
 # Test `fade` parameter and scripts:
 # Must create a new window to ensure javascript is reset.


### PR DESCRIPTION
Addresses an issue brought up here: https://github.com/JuliaGizmos/Blink.jl/issues/150

This PR addresses the issue by loading `blink.js` and `webio.bundle.js` whenever content is loaded using a custom URL. This was achieved by passing the URL of the websocket server to `createWindow` in main.js. This allowed the required JS files to be loaded whenever the Electron BrowserWindow does a navigation (i.e. when Julia calls `loadurl` or creates a window with :url defined).

Also, this PR fixes a warning that would fire every time the `WebSocket` would reconnect or whenever `blink.js` was reloaded. The warning was being fired from here: 

```julia
// server.jl
function ws_handler(ws)
  id = try parse(Int, split(ws.request.target, "/", keepempty=false)[end]) catch e @goto fail end
  haskey(pool, id) || @goto fail
  p = pool[id].value
  active(p) && @goto fail

  p.sock = ws
  @async @errs get(handlers(p), "init", identity)(p)
  try
    put!(p.cb, true) # HERE (Warning: ErrorException("internal consistency error detected for Future"))
  catch e
    @warn e
  end
```

Finally, I saw this `#TODO` in `src/AtomShell/window.jl` that might be relevant to these changes:
<img width="938" alt="Screenshot 2024-01-28 at 11 42 21 PM" src="https://github.com/JuliaGizmos/Blink.jl/assets/9089108/b1b808fe-3a2c-4c35-a144-7cdeb56bfa85">

Is there any way I can address that `#TODO` in this PR?
